### PR TITLE
A little cleaner implementation of verify_request_xhr_status

### DIFF
--- a/lib/action_controller/verification.rb
+++ b/lib/action_controller/verification.rb
@@ -112,7 +112,7 @@ module ActionController #:nodoc:
     end
 
     def verify_request_xhr_status(options) # :nodoc:
-      !!request.xhr? != options[:xhr] unless options[:xhr].nil?
+      !options[:xhr] || request.xhr?
     end
 
     def apply_redirect_to(redirect_to_option) # :nodoc:


### PR DESCRIPTION
This only requires checking the truthyness of options[:xhr] once instead of twice. Should be a little more performant
